### PR TITLE
Adding appendSerdeParams method to HiveUtil

### DIFF
--- a/src/main/java/com/amazonaws/services/glue/catalog/HiveUtils.java
+++ b/src/main/java/com/amazonaws/services/glue/catalog/HiveUtils.java
@@ -1,7 +1,6 @@
 package com.amazonaws.services.glue.catalog;
 
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE;
-import static org.apache.hadoop.hive.ql.exec.DDLTask.appendSerdeParams;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -251,6 +250,19 @@ public class HiveUtils {
 		}
 
 		return retVal;
+	}
+
+	public static StringBuilder appendSerdeParams(
+					StringBuilder builder, Map<String, String> serdeParam) {
+		serdeParam = new TreeMap<String, String>(serdeParam);
+		builder.append("WITH SERDEPROPERTIES ( \n");
+		List<String> serdeCols = new ArrayList<String>();
+		for (Map.Entry<String, String> entry : serdeParam.entrySet()) {
+			serdeCols.add("  '" + entry.getKey() + "'='"
+							+ HiveStringUtils.escapeHiveCommand(entry.getValue()) + "'");
+		}
+		builder.append(StringUtils.join(serdeCols, ", \n")).append(')');
+		return builder;
 	}
 
 }


### PR DESCRIPTION
*Issue #7:*

 Make the agent compatible with hive 2.x

*Description of changes:*

Adding the `appendSerdeParams` utility to `HiveUtils` itself since this method is private in older Hive versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
