### PR TITLE
Apply s3a/s3n replacement on add partition DDL

### DIFF
--- a/src/main/java/com/amazonaws/services/glue/catalog/HiveGlueCatalogSyncAgent.java
+++ b/src/main/java/com/amazonaws/services/glue/catalog/HiveGlueCatalogSyncAgent.java
@@ -1,5 +1,6 @@
 package com.amazonaws.services.glue.catalog;
 
+import static com.amazonaws.services.glue.catalog.HiveUtils.translateLocationToS3Path;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -367,7 +368,7 @@ public class HiveGlueCatalogSyncAgent extends MetaStoreEventListener {
 						if (p.getSd().getLocation().startsWith("s3")) {
 							String addPartitionDDL = String.format(
 									"alter table %s add if not exists partition(%s) location '%s'", fqtn, partitionSpec,
-									p.getSd().getLocation());
+									translateLocationToS3Path(p.getSd().getLocation()));
 							if (!addToAthenaQueue(addPartitionDDL)) {
 								LOG.error("Failed to add the AddPartition event to the processing queue");
 							}

--- a/src/main/java/com/amazonaws/services/glue/catalog/HiveUtils.java
+++ b/src/main/java/com/amazonaws/services/glue/catalog/HiveUtils.java
@@ -49,6 +49,11 @@ public class HiveUtils {
 		return prop_string;
 	}
 
+	public static final String translateLocationToS3Path(final String location) {
+		// Replace s3a/s3n with s3
+		return location.replaceFirst("s3[a,n]://", "s3://");
+	}
+
 	// Copied from Hive's code, it's a private function so had to copy it instead of
 	// reusing.
 	// License: Apache-2.0
@@ -222,8 +227,7 @@ public class HiveUtils {
 
 			String tbl_location = "  '" + HiveStringUtils.escapeHiveCommand(sd.getLocation()) + "'";
 
-			// Replace s3a/s3n with s3
-			tbl_location = tbl_location.replaceFirst("s3[a,n]://", "s3://");
+			tbl_location = translateLocationToS3Path(tbl_location);
 
 			// Table properties
 			duplicateProps.addAll(Arrays.asList(StatsSetupConst.TABLE_PARAMS_STATS_KEYS));


### PR DESCRIPTION
Previously this was only being done on CREATE TABLE DDL.
This patch applies it to ALTER TABLE ADD PARTITION DDLs as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
